### PR TITLE
Added UNIX version

### DIFF
--- a/unix/.gitignore
+++ b/unix/.gitignore
@@ -1,0 +1,4 @@
+images
+xmandelbrot
+mandelbrot
+*~

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -1,0 +1,10 @@
+CC=cc
+CCOPTS=
+
+all: mandelbrot
+
+mandelbrot: mandelbrot.c
+	$(CC) $(CCOPTS) -o mandelbrot mandelbrot.c -lcurses
+clean:
+	rm -f *.o
+	rm -f mandelbrot

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -1,10 +1,15 @@
 CC=cc
-CCOPTS=
+CCOPTS=-Wall -Wpedantic
 
-all: mandelbrot
+all: mandelbrot xmandelbrot
 
 mandelbrot: mandelbrot.c
 	$(CC) $(CCOPTS) -o mandelbrot mandelbrot.c -lcurses
+
+xmandelbrot: xmandelbrot.c
+	$(CC) $(CCOPTS) -o xmandelbrot xmandelbrot.c -lX11
+
 clean:
 	rm -f *.o
 	rm -f mandelbrot
+	rm -f xmandelbrot

--- a/unix/mandelbrot.c
+++ b/unix/mandelbrot.c
@@ -3,6 +3,8 @@
  * Copyright 2025, Andrew C. Young <andrew@vaelen.org>
  * License: MIT
  *
+ * To compile: cc -o mandelbrot mandelbrot.c -lcurses
+ *
  * This program was written on a Macintosh Quadra 700 running A/UX 3.1.
  * A/UX was Apple's first version of UNIX, based on both SYSV and BSD.
  * A/UX 3.1 was released in 1994, and its default C compiler did not
@@ -80,7 +82,7 @@ void cleanup()
 void calculate()
 {
   int i, col, row, iteration;
-  double width, height, x0, y0, x, y, x_scale, y_scale, xtemp;
+  double width, height, x0, y0, x, y, xtemp;
 
   width = (double)cols;
   height = (double)lines;
@@ -115,7 +117,6 @@ void display()
 {
   int i, col, row;
   int value;
-  int color;
   char symbol;
 
   /* Clear the screen */
@@ -155,7 +156,7 @@ double time_in_seconds()
   return t / 60.0;
 }
 
-void main()
+int main()
 {
   double start, after_calc, after_display, calc_time, display_time;
 
@@ -173,5 +174,5 @@ void main()
 
   printf("\nCalculation Time: %0.3f secs, Display Time: %0.3f secs, Total Time: %0.3f secs\n", calc_time, display_time, calc_time + display_time);
 
-  exit(0);
+  return 0;
 }

--- a/unix/mandelbrot.c
+++ b/unix/mandelbrot.c
@@ -1,0 +1,177 @@
+/*
+ * Mandelbrot for UNIX.
+ * Copyright 2025, Andrew C. Young <andrew@vaelen.org>
+ * License: MIT
+ *
+ * This program was written on a Macintosh Quadra 700 running A/UX 3.1.
+ * A/UX was Apple's first version of UNIX, based on both SYSV and BSD.
+ * A/UX 3.1 was released in 1994, and its default C compiler did not
+ * yet support the ANSI standard. As such, this program is written to
+ * work with earlier K&R versions of C. It should also compile with GCC.
+ *
+ * It uses the curses library for screen manipulation, but it should
+ * also work with the later ncurses library.
+ *
+ * My classic Mac resources can be found at m68k.club (www,gopher).
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Used to write to the screen */
+#include <curses.h>
+
+/* Used to measure run time */
+#include <sys/types.h>
+#include <sys/times.h>
+
+#define MAX_ITERATIONS 16
+
+int *pixels = 0;
+int cols = 80;
+int lines = 24;
+
+char symbols[] = {' ','-','+','=','\\','|','/','*',
+                  '#','3','8','B','=','#','+','.'};
+
+char *header = "[ Mandelbrot by Andrew C. Young ]";
+char *footer = "[ Press Any Key to Exit ]";
+
+WINDOW *win = 0;
+
+void init()
+{
+  initscr();
+  nonl(); 
+  cbreak(); 
+  noecho();
+
+  /* Draw Box */
+  wmove(stdscr,0,0);
+  wclear(stdscr);
+  box(stdscr,'|','-');
+  wmove(stdscr,0,0);
+  waddch(stdscr, '+');
+  wmove(stdscr,0,COLS-1);
+  waddch(stdscr, '+');
+  wmove(stdscr,LINES-1,0);
+  waddch(stdscr, '+');
+  wmove(stdscr,LINES-1,COLS-1);
+  waddch(stdscr, '+');
+  wmove(stdscr,0,( (COLS/2) - (strlen(header)/2) -1 ) );
+  waddstr(stdscr, header);
+  wrefresh(stdscr);
+
+  lines = LINES - 2;
+  cols = COLS - 2;
+  win = newwin(lines,cols,1,1);
+  pixels = (int*)malloc(cols*lines*sizeof(int));
+}
+
+void cleanup()
+{
+  if (pixels != 0)
+  {
+    free(pixels);
+  }
+  endwin();
+}
+
+void calculate()
+{
+  int i, col, row, iteration;
+  double width, height, x0, y0, x, y, x_scale, y_scale, xtemp;
+
+  width = (double)cols;
+  height = (double)lines;
+
+  i = 0;
+
+  for (row = 0; row < lines; row++)
+  {
+    y0 = (row * 2.1 / height) - 1;
+    for (col = 0; col < cols; col++)
+    {
+      x0 = (col * 3.5 / width) - 2.5;
+      x = 0.0;
+      y = 0.0;
+      iteration = 0;
+      while ( ((x*x) + (y*y) <= 4) && (iteration < MAX_ITERATIONS))
+      {
+        xtemp = (x*x) - (y*y) + x0;
+        y = (2*x*y) + y0;
+        x = xtemp;
+        iteration++;
+      }
+
+      /* printf("%X",iteration); */
+      pixels[i] = iteration;
+      i++;
+    }
+  }
+}
+
+void display()
+{
+  int i, col, row;
+  int value;
+  int color;
+  char symbol;
+
+  /* Clear the screen */
+  wmove(win,0,0);
+  wclear(win);
+
+  i = 0;
+
+  for (row = 0; row < lines; row++)
+  {
+    wmove(win,row,0);
+    for (col = 0; col < cols; col++)
+    {
+      value = pixels[i];
+      value = value % 16;
+      symbol = symbols[value];
+      waddch(win,symbol);
+      i++;
+    }
+  }
+  wrefresh(win);
+}
+
+void pause()
+{
+  wmove(stdscr,LINES-1,( (COLS/2) - (strlen(footer)/2) -1 ) );
+  waddstr(stdscr, footer);
+  wmove(stdscr,LINES-1,COLS-1);
+  wrefresh(stdscr);
+  getchar();
+}
+
+double time_in_seconds()
+{
+  struct tms buffer;
+  clock_t t = times(&buffer);
+  return t / 60.0;
+}
+
+void main()
+{
+  double start, after_calc, after_display, calc_time, display_time;
+
+  init();
+  start = time_in_seconds();
+  calculate();
+  after_calc = time_in_seconds();
+  display();
+  after_display = time_in_seconds();
+  pause();
+  cleanup();
+
+  calc_time = (after_calc - start); 
+  display_time = (after_display - after_calc); 
+
+  printf("\nCalculation Time: %0.3f secs, Display Time: %0.3f secs, Total Time: %0.3f secs\n", calc_time, display_time, calc_time + display_time);
+
+  exit(0);
+}

--- a/unix/xmandelbrot.c
+++ b/unix/xmandelbrot.c
@@ -13,10 +13,18 @@
 #include <X11/Xutil.h>
 #include <sys/types.h>
 #include <sys/times.h>
-
-#define MAX_ITERATIONS 16
+#include <unistd.h>
 
 char *title = "xmandelbrot";
+
+struct color {
+  unsigned char r, g, b;
+};
+
+struct color colors_1bit[2];
+struct color colors_2bit[4];
+struct color colors_4bit[16];
+struct color colors_8bit[256];
 
 void get_window_size(display, window, height, width)
      Display *display;
@@ -30,16 +38,21 @@ void get_window_size(display, window, height, width)
   XGetGeometry(display, window, &root, &x, &y, width, height, &border, &depth);
 }
 
-unsigned long lookup_color(display, colormap, color_name, color)
+unsigned long lookup_color(display, colormap, color)
      Display *display;
      Colormap colormap;
-     char *color_name;
-     XColor *color;
+     struct color color;
 {
-  XColor exact, screen;
-  if (!XAllocNamedColor(display, colormap, color_name, &exact, &screen))
+  XColor screen;
+
+  /* Convert our 8-bit color space into a 16-bit color space */
+  screen.red = (color.r << 8) | color.r;
+  screen.green = (color.g << 8) | color.g;
+  screen.blue = (color.b << 8) | color.b;
+
+  if (!XAllocColor(display, colormap, &screen))
   {
-    printf("Color Not Found: %s\n", color_name);
+    printf("Color Not Found: rgb:%02x/%02x/%02x\n", color.r, color.g, color.b);
     return 0;
   }
   return screen.pixel;
@@ -75,7 +88,7 @@ void calculate(display, window, gc, palette, palette_size)
 
   for (row = 0; row < lines; row++)
   {
-    //    printf("Row: %u\n", row);
+    //    printf("Row: %u\n", row);q
     y0 = (row * 2.1 / height) - 1;
     for (col = 0; col < cols; col++)
     {
@@ -83,7 +96,7 @@ void calculate(display, window, gc, palette, palette_size)
       x = 0.0;
       y = 0.0;
       iteration = 0;
-      while ( ((x*x) + (y*y) <= 4) && (iteration < MAX_ITERATIONS))
+      while ( ((x*x) + (y*y) <= 4) && (iteration < palette_size) )
       {
         xtemp = (x*x) - (y*y) + x0;
         y = (2*x*y) + y0;
@@ -104,10 +117,129 @@ void calculate(display, window, gc, palette, palette_size)
 
 }
 
+struct color color(r, g, b)
+  unsigned char r, g, b;
+{
+  struct color c;
+  c.r = r;
+  c.g = g;
+  c.b = b;
+  return c;
+}
+
+void initialize_colors()
+{
+  int steps[16];
+  int idx, i, j, v, r, g, b;
+
+  /* Macintosh System 7 1-bit palette (Black, White) */
+  colors_1bit[0] = color(0x00, 0x00, 0x00);
+  colors_1bit[1] = color(0xff, 0xff, 0xff);
+
+  /* Macintosh System 7 2-bit palette */
+  colors_2bit[0] = color(0x00, 0x00, 0x00);
+  colors_2bit[1] = color(0x44, 0x44, 0x44);
+  colors_2bit[2] = color(0xbb, 0xbb, 0xbb);
+  colors_2bit[3] = color(0xff, 0xff, 0xff);
+
+  /* Macintosh System 7 4-bit palette (16 colors, XLib rgb format) */
+  colors_4bit[0]  = color(0x00, 0x00, 0x00);
+  colors_4bit[1]  = color(0x88, 0x00, 0x00);
+  colors_4bit[2]  = color(0x00, 0x88, 0x00);
+  colors_4bit[3]  = color(0x00, 0x00, 0x88);
+  colors_4bit[4]  = color(0x88, 0x88, 0x00);
+  colors_4bit[5]  = color(0x00, 0x88, 0x88);
+  colors_4bit[6]  = color(0x88, 0x00, 0x88);
+  colors_4bit[7]  = color(0x44, 0x44, 0x44);
+  colors_4bit[8]  = color(0xbb, 0xbb, 0xbb);
+  colors_4bit[9]  = color(0xff, 0x88, 0x88);
+  colors_4bit[10] = color(0x88, 0xff, 0x88);
+  colors_4bit[11] = color(0x88, 0x88, 0xff);
+  colors_4bit[12] = color(0xff, 0xff, 0x88);
+  colors_4bit[13] = color(0x88, 0xff, 0xff);
+  colors_4bit[14] = color(0xff, 0x88, 0xff);
+  colors_4bit[15] = color(0xff, 0xff, 0xff);
+
+  /* Macintosh 8-bit system palette (from lospec.com, 256 colors) */
+  idx = 0;
+  
+  steps[0] = 0x00;
+  steps[1] = 0x0b;
+  steps[2] = 0x22;
+  steps[3] = 0x44;
+  steps[4] = 0x55;
+  steps[5] = 0x77;
+  steps[6] = 0x88;
+  steps[7] = 0xaa;
+  steps[8] = 0xbb;
+  steps[9] = 0xdd;
+  steps[10] = 0xee;
+  steps[11] = 0x33;
+  steps[12] = 0x66;
+  steps[13] = 0x99;
+  steps[14] = 0xcc;
+  steps[15] = 0xff;
+
+  /* grayscale */
+  for (i = 0; i < 11; i++) 
+  {
+    v = steps[i];
+    colors_8bit[idx++] = color(v, v, v);
+  }
+
+  /* 10 blue, 10 green, 10 red */
+  for (j = 0; j < 3; j++)
+  {
+    for (i = 1; i < 11; i++) 
+    {
+      v = steps[i];
+      switch (j)
+      {
+        case 0: colors_8bit[idx++] = color(0x00, 0x00, v); break; /* blue */
+        case 1: colors_8bit[idx++] = color(0x00, v, 0x00); break; /* green */
+        case 2: colors_8bit[idx++] = color(v, 0x00, 0x00); break; /* red */
+      }
+    }
+  }
+
+  /* the rest */
+  for (r = 10; r < 16; r++)
+  {
+    for (g = 10; g < 16; g++)
+    {
+      for (b = 10; b < 16; b++)
+      {
+        if (r == 10 && g == 10 && b == 10) continue; /* skip black */
+        colors_8bit[idx++] = color(steps[r == 10 ? 0 : r], steps[g == 10 ? 0 : g], steps[b == 10 ? 0 : b]);
+      }
+    }
+  }
+
+  printf("Initialized %u colors.\n", idx);
+
+}
+
+void create_palette(display, colormap, palette, colors, size)
+     Display *display;
+     Colormap colormap;
+     unsigned long *palette;
+     struct color *colors;
+     size_t size;
+{
+  size_t i;
+  for (i = 0; i < size; i++)
+  {
+    palette[i] = lookup_color(display, colormap, colors[i]);
+  }
+}
+
 int main(argc,argv)
   int argc;
   char **argv;
 {
+
+  /* X11 variables */
+
   Display *display;
   Window  window;
  
@@ -123,40 +255,52 @@ int main(argc,argv)
   int i;
   char text[10];
   int done;
-
+  unsigned int width, height, lastWidth, lastHeight;
+  struct color *colors = colors_8bit;
   Colormap colormap;
   
-  unsigned long palette[16];
-  char *color_names[16];
-  color_names[0] = "Black";
-  color_names[1] = "DarkBlue";
-  color_names[2] = "DarkGreen";
-  color_names[3] = "DarkCyan";
-  color_names[4] = "DarkRed";
-  color_names[5] = "DarkMagenta";
-  color_names[6] = "Brown";
-  color_names[7] = "LightGray";
-  color_names[8] = "Gray";
-  color_names[9] = "Blue";
-  color_names[10] = "Green";
-  color_names[11] = "Cyan";
-  color_names[12] = "Red";
-  color_names[13] = "Magenta";
-  color_names[14] = "Yellow";
-  color_names[15] = "White";
+  unsigned long palette[256];
+
+  int max_iterations = 256;
+  if (argc > 1)
+  {
+    max_iterations = atoi(argv[1]);
+    if (max_iterations < 1 || max_iterations > 256)
+    {
+      fprintf(stderr, "Usage: %s [max_iterations (1-256)]\n", argv[0]);
+      exit(1);
+    }
+  }
+  initialize_colors();
 
   /* setup display/screen */
   display = XOpenDisplay("");
-  
+  if (!display) {
+    fprintf(stderr, "Error: Unable to open display\n");
+    exit(1);
+  }
+
   screen = DefaultScreen(display);
 
   colormap = DefaultColormap(display, screen);
 
-  for (i = 0; i < 16; i++)
+  if (max_iterations < 1 || max_iterations > 256)
   {
-    palette[i] = lookup_color(display, colormap, color_names[i]);
+    fprintf(stderr, "Error: max_iterations must be between 1 and 256\n");
+    exit(1);
   }
-  
+
+  if (max_iterations <= 2)
+    colors = colors_1bit;
+  else if (max_iterations <= 4)
+    colors = colors_2bit;
+  else if (max_iterations <= 16)
+    colors = colors_4bit;
+  else
+    colors = colors_8bit;
+
+  create_palette(display, colormap, palette, colors, max_iterations);
+
   /* drawing contexts for an window */
   bg = BlackPixel(display, screen);
   fg = WhitePixel(display, screen);
@@ -197,9 +341,17 @@ int main(argc,argv)
  
     switch(event.type){
     case Expose:
-      /* Window was showed. */
-      if(event.xexpose.count==0)
-	calculate(display, window, gc, palette, 16);
+      /* Window was shown. */
+      if(event.xexpose.count == 0)
+      {
+        get_window_size(display, window, &height, &width);
+        if (width != lastWidth || height != lastHeight)
+        {
+          calculate(display, window, gc, palette, max_iterations);
+        }
+        lastWidth = width;
+        lastHeight = height;
+      }
       break;
     case MappingNotify:
       /* Modifier key was up/down. */

--- a/unix/xmandelbrot.c
+++ b/unix/xmandelbrot.c
@@ -1,0 +1,225 @@
+/* 
+ * Mandelbrot for X11.
+ * Copyright 2025, Andrew C. Young <andrew@vaelen.org>
+ * License: MIT
+ *
+ * To compile: cc -o xmandelbrot xmandelbrot.c -lX11
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <sys/types.h>
+#include <sys/times.h>
+
+#define MAX_ITERATIONS 16
+
+char *title = "xmandelbrot";
+
+void get_window_size(display, window, height, width)
+     Display *display;
+     Window window;
+     unsigned int *height;
+     unsigned int *width;
+{
+  Window root;
+  int x, y;
+  unsigned int border, depth;
+  XGetGeometry(display, window, &root, &x, &y, width, height, &border, &depth);
+}
+
+unsigned long lookup_color(display, colormap, color_name, color)
+     Display *display;
+     Colormap colormap;
+     char *color_name;
+     XColor *color;
+{
+  XColor exact, screen;
+  if (!XAllocNamedColor(display, colormap, color_name, &exact, &screen))
+  {
+    printf("Color Not Found: %s\n", color_name);
+    return 0;
+  }
+  return screen.pixel;
+}
+
+double time_in_seconds()
+{
+  struct tms buffer;
+  clock_t t = times(&buffer);
+  return t / 60.0;
+}
+
+void calculate(display, window, gc, palette, palette_size)
+  Display *display;
+  Window window;
+  GC gc;
+  unsigned long int *palette;
+  size_t palette_size;
+{
+  unsigned int i, col, row, iteration;
+  double width, height, x0, y0, x, y, xtemp;
+  unsigned int lines, cols;
+  unsigned long color;
+  double start, finish;
+
+  start = time_in_seconds();
+  
+  get_window_size(display, window, &lines, &cols);
+  height = (double)lines;
+  width = (double)cols;
+
+  XClearWindow(display, window);
+
+  for (row = 0; row < lines; row++)
+  {
+    //    printf("Row: %u\n", row);
+    y0 = (row * 2.1 / height) - 1;
+    for (col = 0; col < cols; col++)
+    {
+      x0 = (col * 3.5 / width) - 2.5;
+      x = 0.0;
+      y = 0.0;
+      iteration = 0;
+      while ( ((x*x) + (y*y) <= 4) && (iteration < MAX_ITERATIONS))
+      {
+        xtemp = (x*x) - (y*y) + x0;
+        y = (2*x*y) + y0;
+        x = xtemp;
+        iteration++;
+      }
+
+      i = (iteration % palette_size);
+      color = palette[i];
+      
+      XSetForeground(display, gc, color);
+      XDrawPoint(display, window, gc, col, row);
+    }
+  }
+
+  finish = time_in_seconds();
+  printf("Height: %u, Width: %u, Time: %0.3f Seconds\n", lines, cols, (finish-start));
+
+}
+
+int main(argc,argv)
+  int argc;
+  char **argv;
+{
+  Display *display;
+  Window  window;
+ 
+  GC      gc;
+  
+  XEvent event;
+  KeySym key;
+  
+  XSizeHints hint;
+  
+  int screen;
+  unsigned long fg, bg;
+  int i;
+  char text[10];
+  int done;
+
+  Colormap colormap;
+  
+  unsigned long palette[16];
+  char *color_names[16];
+  color_names[0] = "Black";
+  color_names[1] = "DarkBlue";
+  color_names[2] = "DarkGreen";
+  color_names[3] = "DarkCyan";
+  color_names[4] = "DarkRed";
+  color_names[5] = "DarkMagenta";
+  color_names[6] = "Brown";
+  color_names[7] = "LightGray";
+  color_names[8] = "Gray";
+  color_names[9] = "Blue";
+  color_names[10] = "Green";
+  color_names[11] = "Cyan";
+  color_names[12] = "Red";
+  color_names[13] = "Magenta";
+  color_names[14] = "Yellow";
+  color_names[15] = "White";
+
+  /* setup display/screen */
+  display = XOpenDisplay("");
+  
+  screen = DefaultScreen(display);
+
+  colormap = DefaultColormap(display, screen);
+
+  for (i = 0; i < 16; i++)
+  {
+    palette[i] = lookup_color(display, colormap, color_names[i]);
+  }
+  
+  /* drawing contexts for an window */
+  bg = BlackPixel(display, screen);
+  fg = WhitePixel(display, screen);
+  hint.x = 100;
+  hint.y = 100;
+  hint.width = 500;
+  hint.height = 300;
+  hint.flags = PPosition|PSize;
+ 
+  /* create window */
+  window = XCreateSimpleWindow(display, DefaultRootWindow(display),
+                                 hint.x, hint.y,
+                                 hint.width, hint.height,
+                                 5, fg, bg);
+ 
+  /* window manager properties (yes, use of StdProp is obsolete) */
+  XSetStandardProperties(display, window, title, title,
+                         None, argv, argc, &hint);
+ 
+  /* graphics context */
+  gc = XCreateGC(display, window, 0, 0);
+  XSetBackground(display, gc, bg);
+  XSetForeground(display, gc, fg);
+ 
+  /* allow receiving mouse events */
+  XSelectInput(display,window,
+               ButtonPressMask|KeyPressMask|ExposureMask);
+ 
+  /* show up window */
+  XMapRaised(display, window);
+ 
+  /* event loop */
+  done = 0;
+  while(done==0){
+ 
+    /* fetch event */
+    XNextEvent(display, &event);
+ 
+    switch(event.type){
+    case Expose:
+      /* Window was showed. */
+      if(event.xexpose.count==0)
+	calculate(display, window, gc, palette, 16);
+      break;
+    case MappingNotify:
+      /* Modifier key was up/down. */
+      XRefreshKeyboardMapping(&event.xmapping);
+      break;
+    case ButtonPress:
+      /* Mouse button was pressed. */
+      break;
+    case KeyPress:
+      /* Key input. */
+      i = XLookupString(&event.xkey, text, 10, &key, 0);
+      if(i==1 && text[0]=='q') done = 1;
+      break;
+    }
+  }
+  
+  /* finalization */
+  XFreeGC(display,gc);
+  XDestroyWindow(display, window);
+  XCloseDisplay(display);
+ 
+  exit(0);
+}


### PR DESCRIPTION
<img width="1450" height="1093" alt="image" src="https://github.com/user-attachments/assets/8b1a1216-f156-41c6-83a9-207786652c61" />

Should work on any UNIX variant.

It also provides the time it took to run.

<img width="2494" height="1440" alt="image" src="https://github.com/user-attachments/assets/5000021d-2772-4199-af25-7cdc28130e6a" />

I also added an X11 version:

<img width="1293" height="849" alt="Screenshot from 2025-07-31 18-07-20" src="https://github.com/user-attachments/assets/174d98c7-c6a8-4f0b-a8ad-7f6bdabc59d9" />

Running under A/UX:

![xmandelbrot-large](https://github.com/user-attachments/assets/ac719f37-e55a-4911-b700-2ad799159693)
